### PR TITLE
Fix para los sensores del robot

### DIFF
--- a/src/game/js/entities/entities.js
+++ b/src/game/js/entities/entities.js
@@ -255,8 +255,7 @@ game.PlayerEntity = me.Entity.extend({
 game.WorldFrameEntity = me.Entity.extend({
   init: function() {
     settings = {
-      name : "wordEntity",
-      // image : "",
+      name : "worldEntity",
       width : me.game.viewport.width,
       height : me.game.viewport.height
     };
@@ -274,11 +273,12 @@ game.WorldFrameEntity = me.Entity.extend({
     this.body.shapes[1] = new me.Line(0, 0, [new me.Vector2d(0, 0), 
       new me.Vector2d(0, this.mapHeight)]);
     /* Right line */
-    this.body.shapes[1] = new me.Line(0, 0, [new me.Vector2d(this.mapWidth, 0), 
+    this.body.shapes[2] = new me.Line(0, 0, [new me.Vector2d(this.mapWidth, 0), 
       new me.Vector2d(this.mapWidth, this.mapHeight)]);
     /* Bottom line */
-    this.body.shapes[2] = new me.Line(0, 0, [new me.Vector2d(0, this.mapHeight), 
+    this.body.shapes[3] = new me.Line(0, 0, [new me.Vector2d(0, this.mapHeight), 
       new me.Vector2d(this.mapWidth, this.mapHeight)]);
+
     this.body.updateBounds();
   }
 

--- a/src/game/js/entities/entities.js
+++ b/src/game/js/entities/entities.js
@@ -171,14 +171,14 @@ game.PlayerEntity = me.Entity.extend({
 
     /* Limits checking */
     if(this.pos.x <= this.minX) {
-      this.pos.x = this.minX + 1;
+      this.pos.x = this.minX;
     }
     else if(this.pos.x >= this.maxX) {
       this.pos.x = this.maxX;
     }
 
     if(this.pos.y <= this.minY) {
-      this.pos.y = this.minY + 1;
+      this.pos.y = this.minY + 0.10;
     }
     else if(this.pos.y >= this.maxY) {
       this.pos.y = this.maxY;
@@ -266,7 +266,7 @@ game.WorldFrameEntity = me.Entity.extend({
     this.mapWidth = actualMap.cols * actualMap.tilewidth;
     this.mapHeight = actualMap.rows * actualMap.tileheight;
 
-      /* Top line */
+    /* Top line */
     this.body.shapes[0] = new me.Line(0, 0, [new me.Vector2d(0, 0), 
       new me.Vector2d(this.mapWidth, 0)]);
     /* Left line */

--- a/src/game/js/plugins/debug/debugPanel.js
+++ b/src/game/js/plugins/debug/debugPanel.js
@@ -270,8 +270,8 @@
           _this.sensors.left = this.sensors.left;
           _this.sensors.right = this.sensors.right;
           _this.sensors.front = this.sensors.front;
-          _this.robotPos.x = this.pos.x;
-          _this.robotPos.y = this.pos.y;
+          _this.robotPos.x = Math.round(this.pos.x);
+          _this.robotPos.y = Math.round(this.pos.y);
         }
 
       });


### PR DESCRIPTION
- Como lo describió @sevita en el issue #59 , se arregla el sensado de la pared izquierda.
- Se arreglan también los límites circulables del robot, haciendo que al colisionar con cualquiera de los bordes, el sensor registre 0 como distancia al robot.
- Se modifica el plugin de debugging para obtener la posición del robot en enteros y así visualizar mejor la posición.