### PR TITLE
Limpiar el workspace de Blockly al cambiar de mapa

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,8 @@
     "q": "1.0.1",
     "toastr": "^2.1.2",
     "bootstrap-material-design": "^0.5.10",
-    "keymaster": "^1.6.3"
+    "keymaster": "^1.6.3",
+    "bootbox.js": "^4.4.0"
   },
   "overrides": {
     "bootstrap-sass": {

--- a/src/app/home/home.js
+++ b/src/app/home/home.js
@@ -152,6 +152,7 @@ this.Home = (function() {
 
   module.onMapSelectionClick = function () {
     me.game.changeMap($(this).attr("id"));
+    HomeBlockly.workspace.clear();
     mapsModalElement.modal('hide');
     HomeNavbar.toggleNavbar();
   }

--- a/src/app/home/home.js
+++ b/src/app/home/home.js
@@ -151,12 +151,40 @@ this.Home = (function() {
   }
 
   module.onMapSelectionClick = function () {
-    me.game.changeMap($(this).attr("id"));
-    HomeBlockly.workspace.clear();
+    var selectedMap = $(this).attr("id");
+    // Hide map selection modal.
     mapsModalElement.modal('hide');
     HomeNavbar.toggleNavbar();
+    // If there is no code in workspace, change map. Otherwise, ask for confirmation first.
+    var code = Blockly.JavaScript.workspaceToCode(HomeBlockly.workspace);
+    if (!code || !code.trim().length) {
+      module.onMapChange(selectedMap);
+    } else {
+      bootbox.dialog({
+        message: "Un cambio de mapa eliminará el código existente. Querés continuar?",
+        title: "Cambiar Mapa",
+        buttons: {
+          default: {
+            label: "Cancelar",
+            className: "btn-default"
+          },
+          success: {
+            label: "Cambiar mapa",
+            className: "btn-success",
+            callback: function() {
+              module.onMapChange(selectedMap);
+            }
+          }
+        }
+      });
+    }
   }
   
+  module.onMapChange = function(selectedMap) {
+    HomeSimulator.changeMap(selectedMap);
+    HomeBlockly.workspace.clear();
+  }
+
   return module;
 
 })();

--- a/src/app/home/simulator/simulator.js
+++ b/src/app/home/simulator/simulator.js
@@ -61,6 +61,10 @@ this.HomeSimulator = (function() {
     }
   }
 
+  module.changeMap = function(selectedMap) {
+    me.game.changeMap(selectedMap);
+  }
+
   module.pause = function(onPause) {
     if(me.execution.isRunning()) {
       onPause();


### PR DESCRIPTION
@lausuper Este es igual al PR #73, pero mergea a la branch dev.
Al clickear en el mapa a cambiar, se limpia el código.

También agregué:
Se pide confirmación si el código no está vacío.